### PR TITLE
Fix FileExits behavior

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -19,7 +19,7 @@ const (
 // FileExits returns true if the file exists.
 func FileExits(path string) bool {
 	_, err := os.Stat(path)
-	return err == nil || os.IsExist(err)
+	return err == nil || !os.IsNotExist(err)
 }
 
 // TrimBOM trims the UTF-8 BOM from the line.


### PR DESCRIPTION
## Summary
- make `FileExits` return `false` only when `os.IsNotExist(err)` is true

## Testing
- `go test ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_683f994964e083298e2c9406ca84c55e