### PR TITLE
Add basic Iris web server

### DIFF
--- a/app/web/main.go
+++ b/app/web/main.go
@@ -1,9 +1,0 @@
-package main
-
-import "github.com/Scorpio69t/gcloc/web"
-
-func main() {
-	if err := web.Start(":8080"); err != nil {
-		panic(err)
-	}
-}

--- a/app/web/main.go
+++ b/app/web/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/Scorpio69t/gcloc/web"
+
+func main() {
+	if err := web.Start(":8080"); err != nil {
+		panic(err)
+	}
+}

--- a/cmd/web.go
+++ b/cmd/web.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/Scorpio69t/gcloc/web"
+	"github.com/spf13/cobra"
+)
+
+var (
+	Port = "8080" // Default port for the web server
+)
+
+var webCmd = &cobra.Command{
+	Use:   "web",
+	Short: "Start the web server for gcloc",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := web.Start(":8080"); err != nil {
+			panic(err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(webCmd)
+
+	// Here you will define your flags and configuration settings.
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	webCmd.PersistentFlags().StringVarP(&Port, "port", "p", "8080", "Port to run the web server on")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// webCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/go.mod
+++ b/go.mod
@@ -5,36 +5,76 @@ go 1.20
 require (
 	github.com/go-enry/go-enry/v2 v2.9.1
 	github.com/go-git/go-git/v5 v5.12.0
+	github.com/kataras/iris/v12 v12.2.11
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.8.1
 )
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
+	github.com/BurntSushi/toml v1.3.2 // indirect
+	github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53 // indirect
+	github.com/CloudyKit/jet/v6 v6.2.0 // indirect
+	github.com/Joker/jade v1.1.3 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
+	github.com/Shopify/goreferrer v0.0.0-20220729165902-8cddb4f5de06 // indirect
+	github.com/andybalholm/brotli v1.1.0 // indirect
+	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/fatih/structs v1.1.0 // indirect
+	github.com/flosch/pongo2/v4 v4.0.2 // indirect
 	github.com/go-enry/go-oniguruma v1.2.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/snappy v0.0.4 // indirect
+	github.com/gomarkdown/markdown v0.0.0-20240328165702-4d01890c35c0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/css v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/iris-contrib/schema v0.0.6 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/kataras/blocks v0.0.8 // indirect
+	github.com/kataras/golog v0.1.11 // indirect
+	github.com/kataras/pio v0.0.13 // indirect
+	github.com/kataras/sitemap v0.0.6 // indirect
+	github.com/kataras/tunnel v0.0.4 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
+	github.com/klauspost/compress v1.17.7 // indirect
+	github.com/mailgun/raymond/v2 v2.0.48 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.26 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/schollz/closestmatch v2.1.0+incompatible // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
+	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/skeema/knownhosts v1.2.2 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tdewolff/minify/v2 v2.20.19 // indirect
+	github.com/tdewolff/parse/v2 v2.7.12 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	golang.org/x/crypto v0.21.0 // indirect
-	golang.org/x/mod v0.12.0 // indirect
-	golang.org/x/net v0.22.0 // indirect
-	golang.org/x/sys v0.18.0 // indirect
+	github.com/yosssi/ace v0.0.5 // indirect
+	golang.org/x/crypto v0.22.0 // indirect
+	golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0 // indirect
+	golang.org/x/mod v0.17.0 // indirect
+	golang.org/x/net v0.24.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
+	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/tools v0.13.0 // indirect
+	golang.org/x/time v0.5.0 // indirect
+	golang.org/x/tools v0.20.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/Scorpio69t/gcloc
 
-go 1.20
+go 1.22
+
+toolchain go1.24.0
 
 require (
 	github.com/go-enry/go-enry/v2 v2.9.1

--- a/web/server.go
+++ b/web/server.go
@@ -1,0 +1,163 @@
+package web
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/kataras/iris/v12"
+
+	gcloc "github.com/Scorpio69t/gcloc"
+	"github.com/Scorpio69t/gcloc/pkg/file"
+	"github.com/Scorpio69t/gcloc/pkg/json"
+	"github.com/Scorpio69t/gcloc/pkg/language"
+	"github.com/Scorpio69t/gcloc/pkg/option"
+	"github.com/Scorpio69t/gcloc/pkg/utils"
+)
+
+// AnalyzeRequest defines the parameters accepted by the analyze endpoint.
+type AnalyzeRequest struct {
+	Paths          []string `json:"paths"`
+	ByFile         bool     `json:"byFile"`
+	Sort           string   `json:"sort"`
+	ExcludeExt     string   `json:"excludeExt"`
+	ExcludeLang    string   `json:"excludeLang"`
+	IncludeLang    string   `json:"includeLang"`
+	Match          string   `json:"match"`
+	NotMatch       string   `json:"notMatch"`
+	MatchDir       string   `json:"matchDir"`
+	NotMatchDir    string   `json:"notMatchDir"`
+	Debug          bool     `json:"debug"`
+	SkipDuplicated bool     `json:"skipDuplicated"`
+}
+
+type analyzeResponse struct {
+	json.LanguagesResult `json:",omitempty"`
+	json.FilesResult     `json:",omitempty"`
+	TimeUsed             string `json:"time_used"`
+}
+
+// Start runs the iris server on the given address.
+func Start(addr string) error {
+	app := iris.New()
+
+	app.Get("/languages", languagesHandler)
+	app.Post("/analyze", analyzeHandler)
+
+	return app.Listen(addr)
+}
+
+func languagesHandler(ctx iris.Context) {
+	langs := language.NewDefinedLanguages()
+	result := make([]string, 0, len(langs.Langs))
+	for k := range langs.Langs {
+		result = append(result, k)
+	}
+	ctx.JSON(result)
+}
+
+func analyzeHandler(ctx iris.Context) {
+	var req AnalyzeRequest
+	if err := ctx.ReadJSON(&req); err != nil {
+		ctx.StatusCode(iris.StatusBadRequest)
+		_, _ = ctx.WriteString(err.Error())
+		return
+	}
+
+	var paths []string
+	var repoPaths []string
+	for _, p := range req.Paths {
+		if utils.IsGitURL(p) {
+			temp, err := utils.CloneGitRepo(p)
+			if err != nil {
+				ctx.StatusCode(iris.StatusInternalServerError)
+				_, _ = ctx.WriteString(fmt.Sprintf("clone repo %s failed: %v", p, err))
+				return
+			}
+			paths = append(paths, temp)
+			repoPaths = append(repoPaths, temp)
+		} else {
+			paths = append(paths, p)
+		}
+	}
+	defer func() {
+		for _, p := range repoPaths {
+			_ = os.RemoveAll(p)
+		}
+	}()
+
+	langs := language.NewDefinedLanguages()
+	opts := option.NewGClocOptions()
+	setupOptionsFromRequest(opts, langs, &req)
+
+	parser := gcloc.NewParser(langs, opts)
+	start := time.Now()
+	result, err := parser.Analyze(paths)
+	elapsed := time.Since(start)
+	if err != nil {
+		ctx.StatusCode(iris.StatusInternalServerError)
+		_, _ = ctx.WriteString(err.Error())
+		return
+	}
+
+	if req.ByFile {
+		var files file.GClocFiles
+		for _, f := range result.Files {
+			files = append(files, *f)
+		}
+		resp := analyzeResponse{
+			FilesResult: json.NewFilesResultFromGCloc(result.Total, files),
+			TimeUsed:    fmt.Sprintf("%0.2fs", elapsed.Seconds()),
+		}
+		ctx.JSON(resp)
+		return
+	}
+
+	var langsRes language.Languages
+	for _, l := range result.Languages {
+		if len(l.Files) != 0 {
+			langsRes = append(langsRes, *l)
+		}
+	}
+
+	resp := analyzeResponse{
+		LanguagesResult: json.NewLanguagesResultFromGCloc(result.Total, langsRes),
+		TimeUsed:        fmt.Sprintf("%0.2fs", elapsed.Seconds()),
+	}
+	ctx.JSON(resp)
+}
+
+func setupOptionsFromRequest(clocOpts *option.GClocOptions, langs *language.DefinedLanguages, req *AnalyzeRequest) {
+	for _, ext := range strings.Split(req.ExcludeExt, ",") {
+		if ext != "" {
+			clocOpts.ExcludeExts[ext] = struct{}{}
+		}
+	}
+	for _, l := range strings.Split(req.ExcludeLang, ",") {
+		if _, ok := langs.Langs[l]; ok {
+			clocOpts.ExcludeLanguages[l] = struct{}{}
+		}
+	}
+	for _, l := range strings.Split(req.IncludeLang, ",") {
+		if _, ok := langs.Langs[l]; ok {
+			clocOpts.IncludeLanguages[l] = struct{}{}
+		}
+	}
+	if req.Match != "" {
+		clocOpts.ReMatch = regexp.MustCompile(req.Match)
+	}
+	if req.NotMatch != "" {
+		clocOpts.ReNotMatch = regexp.MustCompile(req.NotMatch)
+	}
+	if req.MatchDir != "" {
+		clocOpts.ReMatchDir = regexp.MustCompile(req.MatchDir)
+	}
+	if req.NotMatchDir != "" {
+		clocOpts.ReNotMatchDir = regexp.MustCompile(req.NotMatchDir)
+	}
+
+	clocOpts.Debug = req.Debug
+	clocOpts.SkipDuplicated = req.SkipDuplicated
+}


### PR DESCRIPTION
## Summary
- add Iris-based web API under `web` package
- expose `/languages` and `/analyze` endpoints
- add `app/web` entrypoint to launch the server
- include iris dependency in go.mod

## Testing
- `go mod tidy`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683f9c096b388329af2e12f08a765b07